### PR TITLE
Jarviz Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2021-03-12
+### Fixed
+- New `continueOnMavenError` flag in `config.json`. When set to `true`, `Jarvis` will continue processing remaining applications, from `artifact.json`, after it encounters maven errors. Default value is `false`.
+- Added capability to use `RELEASE` and `LATEST` as dependency versions in `artifact.json`.
+- `appSetName` is now written to output `jsonl` file.
+
 ## [0.1.3] - 2020-03-12
 ### Fixed
 - Fixed MavenArtifactDiscoveryServiceTest.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Jarviz CLI is a command-line tool designed for \*nix systems to perform dependen
 
 ```json
 {
+  "appSetName": "FooPortfolio",
   "applicationName": "MyApp",
   "artifactFileName": "foo-product-1.2.1.jar",
   "artifactId": "foo-product",

--- a/jarviz-cli/README.md
+++ b/jarviz-cli/README.md
@@ -199,6 +199,7 @@ The output of the `analyze` step is a [JSON Lines (.jsonl)](http://jsonlines.org
 
 ```json
 {
+  "appSetName": "FooPortfolio",
   "applicationName": "MyApp",
   "artifactFileName": "foo-product-1.2.1.jar",
   "artifactId": "foo-product",
@@ -214,6 +215,7 @@ The output of the `analyze` step is a [JSON Lines (.jsonl)](http://jsonlines.org
 
 #### Fields
 
+- `appSetName` - Optional name for the application set.
 - `applicationName` - The human-readable name of the application.
 - `artifactFileName` - The file name of the artifact (e.g. `"foo-product-1.2.1.jar"`).
 - `artifactId` - The id of the artifact (e.g. `"foo-product"`).

--- a/jarviz-cli/samples/config.json
+++ b/jarviz-cli/samples/config.json
@@ -1,3 +1,4 @@
 {
-  "artifactDirectory": "/tmp/jarviz/artifacts"
+  "artifactDirectory": "/tmp/jarviz/artifacts",
+  "continueOnMavenError": false
 }

--- a/jarviz-lib/README.md
+++ b/jarviz-lib/README.md
@@ -9,6 +9,7 @@ This Java library scans the Java [bytecode](https://docs.oracle.com/javase/specs
 
 ```json
 {
+  "appSetName": "FooPortfolio",
   "applicationName": "MyApp",
   "artifactFileName": "foo-product-1.2.1.jar",
   "artifactId": "foo-product",
@@ -240,6 +241,7 @@ The output of `analyze` is a JSON Lines ([`.jsonl`](http://jsonlines.org/)) file
 
 #### Fields
 
+- `appSetName` - Optional name for the application set.
 - `applicationName` - The human readable name of the application.
 - `artifactFileName` - The file name of the artifact (e.g. `"foo-product-1.2.1.jar"`).
 - `artifactId` - The id of the artifact (e.g. `"foo-product"`).

--- a/jarviz-lib/src/main/java/com/vrbo/jarviz/config/JarvizConfig.java
+++ b/jarviz-lib/src/main/java/com/vrbo/jarviz/config/JarvizConfig.java
@@ -41,6 +41,15 @@ public interface JarvizConfig {
     String getArtifactDirectory();
 
     /**
+     * When processing artifacts in a given appSet, should Jarviz ignore any maven
+     * resolution or download errors for any given artifact and continue processing
+     * remaining ones?
+     *
+     * @return Should Jarviz ignore maven errors and continue processing remaining artifacts?
+     */
+    boolean getContinueOnMavenError();
+
+    /**
      * Creates a default config with artifactDirectory set to "/tmp/jarviz/artifacts"
      *
      * @return The {@link JarvizConfig}.

--- a/jarviz-lib/src/main/java/com/vrbo/jarviz/model/Artifact.java
+++ b/jarviz-lib/src/main/java/com/vrbo/jarviz/model/Artifact.java
@@ -16,6 +16,8 @@
 
 package com.vrbo.jarviz.model;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.immutables.value.Value;
@@ -36,6 +38,8 @@ import static com.vrbo.jarviz.model.FileValidationUtils.validFileNamePart;
 @JsonDeserialize(as = ImmutableArtifact.class)
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 public interface Artifact {
+
+    List<String> NON_SPECIFIC_VERSIONS = Arrays.asList("LATEST", "RELEASE");
 
     /**
      * The packaging type of the artifact, default "jar".
@@ -93,16 +97,23 @@ public interface Artifact {
      * For releases: "foo-bar.239.1.jar"
      * With classifier: "foo-bar.239.1-test.jar"
      * Snapshot: "foo-bar-2.0.1-20200708.191052-38.jar"
+     * For unresolvable versions LATEST or RELEASE: "foo-bar.jar"
      *
      * @return The file name.
      */
     @JsonIgnore
     default String toFileName() {
-        return String.format("%s-%s%s.%s",
-                             getArtifactId(),
-                             getVersion(),
-                             getClassifier().map(s -> "-" + s).orElse(""),
-                             getPackaging());
+        if (isVersionLatestOrRelease()) {
+            return String.format("%s.%s",
+                getArtifactId(),
+                getPackaging());
+        } else {
+            return String.format("%s-%s%s.%s",
+                getArtifactId(),
+                getVersion(),
+                getClassifier().map(s -> "-" + s).orElse(""),
+                getPackaging());
+        }
     }
 
     /**
@@ -142,6 +153,16 @@ public interface Artifact {
             final String baseVersion = getBaseVersion().get();
             checkArgument(validFileNamePart(baseVersion), "baseVersion is invalid");
         }
+    }
+
+    /**
+     * Is Version LATEST or RELEASE?
+     *
+     * @return true if version is LATEST or RELEASE, false otherwise.
+     */
+    @Value.Default
+    default boolean isVersionLatestOrRelease() {
+        return NON_SPECIFIC_VERSIONS.contains(getVersion());
     }
 
     class Builder extends ImmutableArtifact.Builder {}

--- a/jarviz-lib/src/main/java/com/vrbo/jarviz/model/Artifact.java
+++ b/jarviz-lib/src/main/java/com/vrbo/jarviz/model/Artifact.java
@@ -16,9 +16,8 @@
 
 package com.vrbo.jarviz.model;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.immutables.value.Value;
 
@@ -39,7 +38,7 @@ import static com.vrbo.jarviz.model.FileValidationUtils.validFileNamePart;
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 public interface Artifact {
 
-    List<String> NON_SPECIFIC_VERSIONS = Arrays.asList("LATEST", "RELEASE");
+    Set<String> NON_SPECIFIC_VERSIONS = Set.of("LATEST", "RELEASE");
 
     /**
      * The packaging type of the artifact, default "jar".

--- a/jarviz-lib/src/main/java/com/vrbo/jarviz/model/CouplingRecord.java
+++ b/jarviz-lib/src/main/java/com/vrbo/jarviz/model/CouplingRecord.java
@@ -28,6 +28,11 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 public interface CouplingRecord {
 
+    /**
+     * The optional name for the application set.
+     *
+     * @return The application set name.
+     */
     String getAppSetName();
 
     /**

--- a/jarviz-lib/src/main/java/com/vrbo/jarviz/model/CouplingRecord.java
+++ b/jarviz-lib/src/main/java/com/vrbo/jarviz/model/CouplingRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 public interface CouplingRecord {
 
+    String getAppSetName();
+
     /**
      * The human readable name of the application.
      *

--- a/jarviz-lib/src/main/java/com/vrbo/jarviz/service/CouplingAnalyser.java
+++ b/jarviz-lib/src/main/java/com/vrbo/jarviz/service/CouplingAnalyser.java
@@ -99,7 +99,7 @@ public class CouplingAnalyser {
 
         final CouplingRecordWriter writer = new CouplingRecordWriter(reportFile);
         for (Application application : appSet.getApplications()) {
-            appSetCouplingCount += analyzeApplication(application, filterConfig, classLoaderService, writer);
+            appSetCouplingCount += analyzeApplication(appSet, application, filterConfig, classLoaderService, writer);
         }
 
         log.info("ApplicationSet={}, TotalClassesAnalyzed={}, TotalCouplingsFound={}",
@@ -120,7 +120,8 @@ public class CouplingAnalyser {
      * @param writer             Coupling record writer.
      * @return Coupling count for the application.
      */
-    private int analyzeApplication(final Application app,
+    private int analyzeApplication(final ApplicationSet appSet,
+                                   final Application app,
                                    final CouplingFilterConfig filterConfig,
                                    final ClassLoaderService classLoaderService,
                                    final CouplingRecordWriter writer) {
@@ -131,7 +132,7 @@ public class CouplingAnalyser {
         for (Artifact artifact : app.getArtifacts()) {
             log.info("Analyzing artifact: {}", artifact.toFileName());
 
-            appCouplingCount += analyzeArtifact(app, artifact, filterConfig, classLoaderService, writer);
+            appCouplingCount += analyzeArtifact(appSet, app, artifact, filterConfig, classLoaderService, writer);
         }
 
         log.info("Application={}, TotalClassesAnalyzed={}, TotalCouplingsFound={}",
@@ -150,7 +151,8 @@ public class CouplingAnalyser {
      * @param writer             Coupling record writer.
      * @return Coupling count for the artifact.
      */
-    private int analyzeArtifact(final Application app,
+    private int analyzeArtifact(final ApplicationSet appSet,
+                                final Application app,
                                 final Artifact artifact,
                                 final CouplingFilterConfig filterConfig,
                                 final ClassLoaderService classLoaderService,
@@ -171,16 +173,18 @@ public class CouplingAnalyser {
 
         // Write the CouplingRecord as Json
         couplings.stream()
-                 .map(c -> toCouplingRecord(app, artifact, c))
+                 .map(c -> toCouplingRecord(appSet, app, artifact, c))
                  .forEach(writer::writeAsJson);
 
         return couplings.size();
     }
 
-    private static CouplingRecord toCouplingRecord(final Application app,
+    private static CouplingRecord toCouplingRecord(final ApplicationSet appSet,
+                                                   final Application app,
                                                    final Artifact artifact,
                                                    final MethodCoupling methodCoupling) {
         return new CouplingRecord.Builder()
+                   .appSetName(appSet.getAppSetName().orElse(""))
                    .applicationName(app.getAppName())
                    .artifactFileName(artifact.toFileName())
                    .artifactId(artifact.getArtifactId())

--- a/jarviz-lib/src/test/java/com/vrbo/jarviz/model/ArtifactTest.java
+++ b/jarviz-lib/src/test/java/com/vrbo/jarviz/model/ArtifactTest.java
@@ -74,6 +74,52 @@ public class ArtifactTest {
     }
 
     @Test
+    public void testToFileName_WhenVersionIsUnspecified() {
+
+        final Artifact releaseVerArtifact =
+            new Artifact.Builder()
+                .artifactId("api-service")
+                .groupId("com.vrbo.api")
+                .version("RELEASE")
+                .build();
+
+        assertThat(releaseVerArtifact.toFileName())
+            .isEqualTo("api-service.jar");
+
+        assertThat(new Artifact.Builder()
+                        .from(releaseVerArtifact)
+                        .classifier("logic")
+                        .build()
+                        .toFileName())
+                        .isEqualTo("api-service.jar");
+
+        assertThat(new Artifact.Builder()
+                        .from(releaseVerArtifact)
+                        .packaging("war")
+                        .build()
+                        .toFileName())
+                        .isEqualTo("api-service.war");
+
+        final Artifact latestVerArtifact =
+            new Artifact.Builder()
+                .artifactId("foo-bar")
+                .groupId("abc.xyz")
+                .version("LATEST")
+                .build();
+
+        assertThat(latestVerArtifact.toFileName())
+            .isEqualTo("foo-bar.jar");
+
+        assertThat(new Artifact.Builder()
+                    .from(latestVerArtifact)
+                    .version("LATEST")
+                    .baseVersion(Optional.empty())
+                    .build()
+                    .toFileName())
+                    .isEqualTo("foo-bar.jar");
+    }
+
+    @Test
     public void testToMavenId() {
 
         assertThat(releaseArtifact.toMavenId())

--- a/jarviz-lib/src/test/java/com/vrbo/jarviz/service/MavenArtifactDiscoveryServiceTest.java
+++ b/jarviz-lib/src/test/java/com/vrbo/jarviz/service/MavenArtifactDiscoveryServiceTest.java
@@ -35,6 +35,7 @@ public class MavenArtifactDiscoveryServiceTest {
         artifactDiscoveryService = new MavenArtifactDiscoveryService(
             new JarvizConfig.Builder()
                 .artifactDirectory("/tmp/jarviz/artifacts")
+                .continueOnMavenError(false)
                 .build());
     }
 
@@ -59,4 +60,19 @@ public class MavenArtifactDiscoveryServiceTest {
         artifactDiscoveryService.discoverArtifact(artifact);
     }
 
+    @Test
+    public void testDiscoverArtifact_WhenContinueOnMavenError_IsTrue() throws ArtifactNotFoundException {
+        final MavenArtifactDiscoveryService artifactDiscoveryService2 = new MavenArtifactDiscoveryService(
+            new JarvizConfig.Builder()
+                .artifactDirectory("/tmp/jarviz/artifacts")
+                .continueOnMavenError(true)
+                .build());
+        final Artifact artifact = new Artifact.Builder()
+                                        .groupId("__my_invalid_group__")
+                                        .artifactId("__my_invalid_artifact__")
+                                        .version("0")
+                                        .build();
+        final File file = artifactDiscoveryService2.discoverArtifact(artifact);
+        assertThat(file).doesNotExist();
+    }
 }


### PR DESCRIPTION
### :pencil: Description

- New `continueOnMavenError` flag in `config.json`. When set to `true`, `Jarvis` will continue processing remaining applications, from `artifact.json`, after it encounters maven errors. Default value is `false`.
- Added capability to use `RELEASE` and `LATEST` as dependency versions in `artifact.json`.
- `appSetName` is now written to output `jsonl` file.

### :link: Related Issues
