### PR TITLE
Fix CouplingFilter bug where not all exclusion rules are getting applied

### DIFF
--- a/jarviz-lib/README.md
+++ b/jarviz-lib/README.md
@@ -229,6 +229,13 @@ See the full sample file: [filter.json](../jarviz-cli/samples/filter.json)
 - `targetMethod` - Optional RegEx pattern to match with the method name (of the target class) in the coupling.
     - e.g. `^myMethod$` - To exactly match a method name to `myMethod`.
 
+#### Filtering using include and exclude
+
+Filtering can be done using include and exclude patterns at the package, class or method level. This is how filtering rules are applied:
+
+- `include` - Include rules are evaluated first. If includes are not provided, then all couplings in this scan will be included. If includes are provided, then a coupling must match all the provided include patterns (package, class and method). This uses an AND condition between provided include patterns.
+- `exclude` - Excludes are evaluated for all couplings that pass include rules. If excludes are not provided, then all couplings are included. If excludes are provided, then a coupling must not match any of the provided exclude patterns (package, class or method). This uses an OR condition between provided exclude patterns.
+
 #### Java References
 
 | Link |

--- a/jarviz-lib/src/test/java/com/vrbo/jarviz/model/CouplingFilterUtilsTest.java
+++ b/jarviz-lib/src/test/java/com/vrbo/jarviz/model/CouplingFilterUtilsTest.java
@@ -108,7 +108,7 @@ public class CouplingFilterUtilsTest {
     }
 
     @Test
-    public void testFilterMethodCouplingSelfExclude() {
+    public void testFilterMethodCoupling_includeExcludeUseCases() {
         final MethodCoupling samePkgSourceTargetCoupling = new MethodCoupling.Builder()
                                             .source(new Method.Builder()
                                                 .className("com.foo.MySourceClass")
@@ -127,6 +127,17 @@ public class CouplingFilterUtilsTest {
                                             .exclude(new CouplingFilter.Builder()
                                                 .sourcePackage("^com\\.foo$")
                                                 .targetPackage("^com\\.foo\\.bar$")
+                                                .build())
+                                            .build(),
+                                        samePkgSourceTargetCoupling)).isFalse();
+
+        assertThat(filterMethodCoupling(new CouplingFilterConfig.Builder()
+                                            .include(new CouplingFilter.Builder()
+                                                .targetMethod("^whyDoYouCallMe$")
+                                                .build())
+                                            .exclude(new CouplingFilter.Builder()
+                                                .sourceMethod("^iAmCallingYou$")
+                                                .targetMethod("^why.*?")
                                                 .build())
                                             .build(),
                                         samePkgSourceTargetCoupling)).isFalse();
@@ -153,7 +164,7 @@ public class CouplingFilterUtilsTest {
                                         .build(),
                                     diffPkgSourceTargetCoupling)).isTrue();
     }
-  
+
     @Test
     public void testFilterMethodCoupling_withWildCards() {
         final MethodCoupling coupling1 =


### PR DESCRIPTION
### :pencil: Description

Right now, include exclude filters are not working as expected. Ideally, 

- Include rules should be evaluated first and should use an AND condition between provided include patterns (at package, class or method levels). 
- Excludes should use an OR condition between provided exclude patterns.

This PR should fix the bug in v0.1.5.